### PR TITLE
Remove pkg-resources dependency

### DIFF
--- a/spyndex/utils.py
+++ b/spyndex/utils.py
@@ -1,5 +1,4 @@
 import json
-import os
 from pathlib import Path
 
 import requests

--- a/spyndex/utils.py
+++ b/spyndex/utils.py
@@ -1,7 +1,7 @@
 import json
 import os
+from pathlib import Path
 
-import pkg_resources
 import requests
 
 import spyndex
@@ -20,10 +20,7 @@ def _load_JSON(file="spectral-indices-dict.json"):
     object
         JSON file.
     """
-    spyndexDir = os.path.dirname(
-        pkg_resources.resource_filename("spyndex", "spyndex.py")
-    )
-    dataPath = os.path.join(spyndexDir, "data/" + file)
+    dataPath = Path(__file__).parent / "data" / file
     f = open(dataPath)
     return json.load(f)
 


### PR DESCRIPTION
Fixes #28 

Now importing spyndex throws such warning:

```
[C:\ProgramData\miniforge3\envs\geo\Lib\site-packages\spyndex\utils.py:4]: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
```

Probably `pkg_resources` shouldn't be used anymore.