### PR TITLE
Add pyarrow dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ eemont
 matplotlib
 numpy
 pandas
+pyarrow
 python-box
 requests
 seaborn


### PR DESCRIPTION
When I tried to install spyndex dependencies into a clean venv via `python -m pip install requirements.txt` and then import spyndex, I got such error:

```
>>> import spyndex
Traceback (most recent call last):
  File "C:\Users\mosko\Documents\spyndex\.venv\Lib\site-packages\dask\_compatibility.py", line 114, in import_optional_dependency
    module = importlib.import_module(name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_3.11.2544.0_x64__qbz5n2kfra8p0\Lib\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1140, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'pyarrow'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\mosko\Documents\spyndex\spyndex\__init__.py", line 8, in <module>
    from .axioms import bands, constants, indices
  File "C:\Users\mosko\Documents\spyndex\spyndex\axioms.py", line 3, in <module>
    from .spyndex import computeIndex
  File "C:\Users\mosko\Documents\spyndex\spyndex\spyndex.py", line 6, in <module>
    import dask.dataframe as dd
  File "C:\Users\mosko\Documents\spyndex\.venv\Lib\site-packages\dask\dataframe\__init__.py", line 24, in <module>
    from dask.dataframe import backends, dispatch
  File "C:\Users\mosko\Documents\spyndex\.venv\Lib\site-packages\dask\dataframe\backends.py", line 14, in <module>
    from dask.dataframe._compat import PANDAS_GE_220, is_any_real_numeric_dtype
  File "C:\Users\mosko\Documents\spyndex\.venv\Lib\site-packages\dask\dataframe\_compat.py", line 11, in <module>
    import_optional_dependency("pyarrow")
  File "C:\Users\mosko\Documents\spyndex\.venv\Lib\site-packages\dask\_compatibility.py", line 117, in import_optional_dependency
    raise ImportError(msg) from err
ImportError: Missing optional dependency 'pyarrow'.  Use pip or conda to install pyarrow.
```

Maybe we should add `pyarrow` to requirements?